### PR TITLE
Implemented text content

### DIFF
--- a/pkg/el/el_test.go
+++ b/pkg/el/el_test.go
@@ -14,6 +14,13 @@ func ExampleNew() {
 	// Output: <div></div>
 }
 
+func ExampleText() {
+	text := Text("abc")
+	fmt.Println(text)
+
+	// Output: abc
+}
+
 func ExampleWithAttr() {
 	id := attr.New("id", "my-id")
 	el := New("div", WithAttr(id))
@@ -42,4 +49,11 @@ func ExampleWithChild() {
 	fmt.Println(el)
 
 	// Output: <div><span></span></div>
+}
+
+func ExampleWithText() {
+	parent := New("p", WithText("abc"))
+	fmt.Println(parent)
+
+	// Output: <p>abc</p>
 }


### PR DESCRIPTION
Implemented a technique for inserting text content as a child element. The text content is stored in a property `El.TextContent` and is returned by `El.String()` if the element's tag has been set as text content via the constant tag provided by `TAG_TEXT_CONTENT`. Functions `el.Text()` and  `el.WithText()` are here to facilitate this process.